### PR TITLE
Change Save Implementation

### DIFF
--- a/SaveAllTheTime/SaveAllTheTime.cs
+++ b/SaveAllTheTime/SaveAllTheTime.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 using Microsoft.VisualStudio.Text;
 using System.Reactive.Concurrency;
 using System.Windows.Forms;
+using EnvDTE;
 
 namespace SaveAllTheTime
 {
@@ -18,16 +19,18 @@ namespace SaveAllTheTime
     sealed class SaveAllTheTime : Canvas, IWpfTextViewMargin
     {
         public const string MarginName = "SaveAllTheTime";
-        IWpfTextView _textView;
+        readonly IWpfTextView _textView;
+        readonly DTE _dte;
         IDisposable _inner;
 
         /// <summary>
         /// Creates a <see cref="SaveAllTheTime"/> for a given <see cref="IWpfTextView"/>.
         /// </summary>
         /// <param name="textView">The <see cref="IWpfTextView"/> to attach the margin to.</param>
-        public SaveAllTheTime(IWpfTextView textView)
+        public SaveAllTheTime(IWpfTextView textView, DTE dte)
         {
             _textView = textView;
+            _dte = dte;
 
             this.Height = 0;
             this.Visibility = Visibility.Collapsed;
@@ -87,6 +90,16 @@ namespace SaveAllTheTime
             var disp = Interlocked.Exchange(ref _inner, null);
             if (disp != null) {
                 disp.Dispose();
+            }
+        }
+
+        void SaveAll()
+        {
+            try {
+                _dte.ExecuteCommand("File.SaveAll");
+            }
+            catch (Exception) {
+
             }
         }
     }

--- a/SaveAllTheTime/SaveAllTheTime.csproj
+++ b/SaveAllTheTime/SaveAllTheTime.csproj
@@ -39,9 +39,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>

--- a/SaveAllTheTime/SaveAllTheTimeFactory.cs
+++ b/SaveAllTheTime/SaveAllTheTimeFactory.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
 
 namespace SaveAllTheTime
 {
@@ -17,9 +19,17 @@ namespace SaveAllTheTime
     [TextViewRole(PredefinedTextViewRoles.Interactive)]
     internal sealed class MarginFactory : IWpfTextViewMarginProvider
     {
+        readonly DTE _dte;
+
+        [ImportingConstructor]
+        internal MarginFactory(SVsServiceProvider vsServiceProvider)
+        {
+            _dte = (DTE)vsServiceProvider.GetService(typeof(_DTE));
+        }
+
         public IWpfTextViewMargin CreateMargin(IWpfTextViewHost textViewHost, IWpfTextViewMargin containerMargin)
         {
-            return new SaveAllTheTime(textViewHost.TextView);
+            return new SaveAllTheTime(textViewHost.TextView, _dte);
         }
     }
     #endregion


### PR DESCRIPTION
The previous method of saving all files used the indirect method of
sending the Ctrl+Alt+S keystroke to Visual Studio.  While uncommon it is
possible for users or extensions to remap the Ctrl+Alt+S keystroke to a
different Visual Studio command.  If that happened the SaveAllTheTime
extension would begin executing that command instead of saving.

I switched the save implementation to use the more direct route of
actually executing the File.SaveAll command.  This is what Ctrl+Alt+S is
bound to by default.
