### PR TITLE
Also support Visual Studio 2013.

### DIFF
--- a/SaveAllTheTime/source.extension.vsixmanifest
+++ b/SaveAllTheTime/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
     <Tags>git</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="11.0" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,12.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />


### PR DESCRIPTION
This commit adds support for Visual Studio 2013 to SaveAllTheTime. According to [this post](http://blogs.msdn.com/b/visualstudio/archive/2013/08/08/update-for-extension-authors-vsix-manifest-version-ranges.aspx,), the version number format has changed for VS 2013, so that a single version number now means "support this specific version only", much like [##.#] did before. The same behaviour as before can be achieved by specifying a supported version of [##.#,].

I have chosen to explicitly specify VS2012 and VS2013 only, as I have no idea whether or not SaveAllTheTime will continue to work with the next version of Visual Studio after VS2013 :smile:
## Still TODO:
- [x] Finish installing VS 2012
- [x] Install VS 2012 SDK
- [x] Build in VS 2012
- [x] Test in VS 2012
- [x] Test in VS 2013
