### PR TITLE
Fix for Issues #19 and #25

### DIFF
--- a/SaveAllTheTime/Extensions.cs
+++ b/SaveAllTheTime/Extensions.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace SaveAllTheTime
 {
-    using System;
-    using System.Linq;
 
-    using EnvDTE;
 
     internal static class Extensions
     {
@@ -57,8 +56,7 @@ namespace SaveAllTheTime
 
         private static IEnumerable<ProjectItem> AllProjectItems(Project project)
         {
-            if (project == null || project.ProjectItems == null)
-            {
+            if (project == null || project.ProjectItems == null) {
                 yield break;
             }
 
@@ -75,8 +73,7 @@ namespace SaveAllTheTime
 
         private static IEnumerable<ProjectItem> SubProjectItems(ProjectItem item)
         {
-            if (item == null || item.ProjectItems == null)
-            {
+            if (item == null || item.ProjectItems == null) {
                 yield break;
             }
 


### PR DESCRIPTION
This _should_ fix issues #19 and #25 without breaking anything else. I think it may also solve issue #20 and #23.

For issue #19 - if the active document is a resx file then the SaveAll method returns before saving documents. I added an event handler to EnvDTE.Events.WindowEvents.WindowActivated to call RaiseChanged when switching documents, this triggers a Save on the resx file as soon as the resx file is no longer the ActiveDocument.

For issue #25 - I added a call to ShouldSaveActiveDocument in the SaveAll, this checks to see if the ActiveDocument is a project item. Project items will never prompt for a SaveAs, so this should be the same as checking to see if a file has been saved at least once. I could not find anything in the VS API that indicates a file state of NEW/UNSAVED, maybe there is something in the DocumentMonitorService but I am not familiar with it. I _think_ this also fixes issue #20 and #23 but I do not have TFS or SnippetDesigner to test with.

Feel free to comment on any potential issues with the implementation, or code/style issues, I will do my best to fix any issues. I've been using a build of this PR today and its working for me, tested with R# 8.0.1 on VS2012 on Windows 7
