### PR TITLE
Files are not saved, because the "FullPath" Property throws an exception when a virtual folder is present in the project.

### DIFF
--- a/SaveAllTheTime/Extensions.cs
+++ b/SaveAllTheTime/Extensions.cs
@@ -47,7 +47,7 @@ namespace SaveAllTheTime
         {
             var projectItems = solution.AllProjects()
                 .SelectMany(x => AllProjectItems(x)
-                    .Where(y => y.Properties != null)
+                    .Where(y => y.Kind != EnvDTE.Constants.vsProjectItemKindVirtualFolder && y.Properties != null)
                     .Select(y => y.Properties.Item("FullPath"))
                     .Where(z => z.Value != null)
                     .Select(z => z.Value.ToString()));


### PR DESCRIPTION
Hi, I've found that SaveAllTheTime did not work for several of my C++ projects in VS2015 and tracked it down to an InvalidArgumentException when the "FullPath" of a ProjectItem property was being accessed. I guess "FullPath" is just not available on virtual folders. An additional test for the ProjectItem's kind fixed the problem.

To reproduce the problem, create a new C++/Win32 Console Application. The existence of the virtual folders prevents SaveAllTheTime to automatically save the changed files as expected.

May be related to #47.