### PR TITLE
Refresh the commit hint on the UI thread

### DIFF
--- a/SaveAllTheTime/Views/CommitHintView.xaml.cs
+++ b/SaveAllTheTime/Views/CommitHintView.xaml.cs
@@ -125,7 +125,7 @@ namespace SaveAllTheTime.Views
 
         void applyElementVisualState(string state)
         {
-            VisualStateManager.GoToElementState(visualRoot, state, true);
+            Dispatcher.InvokeAsync(() => VisualStateManager.GoToElementState(visualRoot, state, true));
         }
     }
 }


### PR DESCRIPTION
After updating VS2015 to Update 3 (or maybe a later incremental update), SaveAllTheTime started crashing when displaying the commit hint. I fixed this fairly trivially by using the WPF Dispatcher to execute the change in visual state.

The stack trace for the crash was

```
ReactiveObject Subscriber threw exception
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it.
   at System.Windows.Threading.Dispatcher.VerifyAccess()
   at System.Windows.DependencyObject.SetValue(DependencyProperty dp, Object value)
   at System.Windows.UIElement.set_Opacity(Double value)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, Object[] index)
   at ReactiveUI.Reflection.<>c__DisplayClass2b.<.cctor>b__22(Object y, Object v)
   at ReactiveUI.PropertyBinderImplementation.<>c__DisplayClass25`2.<bindToDirect>b__21(<>f__AnonymousType0`2 x)
   at System.Reactive.AnonymousSafeObserver`1.OnNext(T value)
   at System.Reactive.Linq.ObservableImpl.Where`1._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.CombineLatest`3._.F.OnNext(TFirst value)
   at System.Reactive.Linq.ObservableImpl.SelectMany`2._.Iter.OnNext(TResult value)
   at System.Reactive.Linq.ObservableImpl.Return`1._.Invoke()
   at System.Reactive.Concurrency.Scheduler.Invoke(IScheduler scheduler, Action action)
   at System.Reactive.Concurrency.ImmediateScheduler.Schedule[TState](TState state, Func`3 action)
   at System.Reactive.Concurrency.Scheduler.Schedule(IScheduler scheduler, Action action)
   at System.Reactive.Linq.ObservableImpl.Return`1._.Run()
   at System.Reactive.Linq.ObservableImpl.Return`1.Run(IObserver`1 observer, IDisposable cancel, Action`1 setSink)
   at System.Reactive.Producer`1.SubscribeRaw(IObserver`1 observer, Boolean enableSafeguard)
   at System.ObservableExtensions.SubscribeSafe[T](IObservable`1 source, IObserver`1 observer)
   at System.Reactive.Linq.ObservableImpl.SelectMany`2._.SubscribeInner(IObservable`1 inner)
   at System.Reactive.Linq.ObservableImpl.SelectMany`2._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Select`2._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Select`2._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.DistinctUntilChanged`2._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Select`2._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Select`2._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Where`1._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Switch`1._.Iter.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Concat`1._.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Select`2._.OnNext(TSource value)
   at System.Reactive.AutoDetachObserver`1.OnNextCore(T value)
   at System.Reactive.ObserverBase`1.OnNext(T value)
   at System.Reactive.SafeObserver`1.OnNext(TSource value)
   at System.Reactive.Linq.ObservableImpl.Where`1._.OnNext(TSource value)
   at System.Reactive.Observer`1.OnNext(T value)
   at System.Reactive.Subjects.Subject`1.OnNext(T value)
   at ReactiveUI.ReactiveObject.notifyObservable[T](T item, Subject`1 subject)
```

(Thrown by SATT 8 times before .NET and then VS died.)
